### PR TITLE
Refactor: Add explicit declaration of $ErrorView = 'NormalView' for use with PowerShell 7

### DIFF
--- a/src/scripts/ci/Invoke-Generate.ps1
+++ b/src/scripts/ci/Invoke-Generate.ps1
@@ -2,6 +2,7 @@
 param()
 
 $ErrorActionPreference = 'Stop'
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 Set-StrictMode -Version Latest
 

--- a/src/scripts/ci/Invoke-Release.ps1
+++ b/src/scripts/ci/Invoke-Release.ps1
@@ -2,6 +2,7 @@
 param()
 
 $ErrorActionPreference = 'Stop'
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 Set-StrictMode -Version Latest
 

--- a/src/scripts/dev/Invoke-Generate.ps1
+++ b/src/scripts/dev/Invoke-Generate.ps1
@@ -14,6 +14,7 @@ $private:myGenerateArgs = @{
 ################################################
 
 $ErrorActionPreference = 'Stop'
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 Set-StrictMode -Version Latest
 

--- a/src/scripts/dev/Invoke-Release.ps1
+++ b/src/scripts/dev/Invoke-Release.ps1
@@ -28,6 +28,7 @@ $private:myReleaseArgs = @{
 ################################################
 
 $ErrorActionPreference = 'Stop'
+$ErrorView = 'NormalView'
 $VerbosePreference = 'Continue'
 Set-StrictMode -Version Latest
 

--- a/templates/azure-pipelines/entrypoint/generate.yml
+++ b/templates/azure-pipelines/entrypoint/generate.yml
@@ -5,6 +5,7 @@ parameters:
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }

--- a/templates/azure-pipelines/entrypoint/powershell/generate.yml
+++ b/templates/azure-pipelines/entrypoint/powershell/generate.yml
@@ -5,6 +5,7 @@ parameters:
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }

--- a/templates/azure-pipelines/entrypoint/powershell/release.yml
+++ b/templates/azure-pipelines/entrypoint/powershell/release.yml
@@ -9,6 +9,7 @@ parameters:
 steps:
 - powershell: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }

--- a/templates/azure-pipelines/entrypoint/pwsh/generate.yml
+++ b/templates/azure-pipelines/entrypoint/pwsh/generate.yml
@@ -5,6 +5,7 @@ parameters:
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }

--- a/templates/azure-pipelines/entrypoint/pwsh/release.yml
+++ b/templates/azure-pipelines/entrypoint/pwsh/release.yml
@@ -9,6 +9,7 @@ parameters:
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }

--- a/templates/azure-pipelines/entrypoint/release.yml
+++ b/templates/azure-pipelines/entrypoint/release.yml
@@ -9,6 +9,7 @@ parameters:
 steps:
 - pwsh: |
     $ErrorActionPreference = 'Stop'
+    $ErrorView = 'NormalView'
     ### Begin CI-specific code: Get the namspace, project name, and tag ref
     $matchInfo = $env:BUILD_SOURCEBRANCH | Select-String -Pattern '^refs\/tags\/(.*)'
     $env:RELEASE_TAG_REF = if ($matchInfo) { $matchInfo.Matches.Groups[1].Value } else { $null }


### PR DESCRIPTION
PowerShell 7 defaults to `$ErrorView = 'ConciseView'` which can be limiting for debugging. We'll use `$ErrorView = 'NormalView'` so more details of thrown errors can be reviewed in CI logs.
